### PR TITLE
clone from https url

### DIFF
--- a/busy.yaml
+++ b/busy.yaml
@@ -1,8 +1,8 @@
 name: Serializer
 extRepositories:
-  - url: git@github.com:SGSSGene/gtest
-  - url: git@github.com:SGSSGene/jsoncpp
-  - url: git@github.com:SGSSGene/yaml-cpp
+  - url: https://github.com/SGSSGene/gtest
+  - url: https://github.com/SGSSGene/jsoncpp
+  - url: https://github.com/SGSSGene/yaml-cpp
 projects:
     - name: exampleSerializer
       type: executable


### PR DESCRIPTION
simplify installing for users that just want to use Serializer as a tool
